### PR TITLE
Addresses Memory Bloat

### DIFF
--- a/lib/new_relic_logger.rb
+++ b/lib/new_relic_logger.rb
@@ -1,5 +1,4 @@
 require "new_relic_logger/host"
-require 'logger'
 
 module NewRelicLogger
   class ConfigurationError < StandardError; end

--- a/lib/new_relic_logger/host.rb
+++ b/lib/new_relic_logger/host.rb
@@ -1,21 +1,29 @@
 require 'net/http'
+require "new_relic_logger/log_queue"
 
 module NewRelicLogger
   class Host
-    STOP_MESSAGE   = :stop
-    STOP_MAX_WAIT  = 10 # max seconds to wait for queue shutdown clearing
-    STOP_WAIT_STEP = 0.2 # sleep duration (seconds) while shutting down
-
     REGIONS = {
       'us' => URI('https://log-api.newrelic.com/log/v1'),
       'eu' => URI('https://log-api.eu.newrelic.com/log/v1')
     }
 
+    QUEUE_SIZE         = ENV.fetch('NEW_RELIC_LOGGING_QUEUE_SIZE') { 100 }.to_i
+    QUEUE_WAIT_TIMEOUT = ENV.fetch('NEW_RELIC_LOGGING_QUEUE_WAIT_TIMEOUT') { 30 }.to_i
+
+    LOGS_PAYLOAD       = [{ logs: [] }].to_json.freeze
+    LOGS_PAYLOAD_REGEX = /(\[\])/.freeze
+    OPEN_BRACKET       = '['.freeze
+    CLOSE_BRACKET      = ']'.freeze
+
+    STOP_MAX_WAIT  = 10 # max seconds to wait for queue shutdown clearing
+    STOP_WAIT_STEP = 0.2 # sleep duration (seconds) while shutting down
+
     def initialize(license_key, region)
       @license_key  = license_key
       @region       = region
 
-      @queue   = Queue.new
+      @queue   = NewRelicLogger::LogQueue.new(QUEUE_SIZE)
       @thread  = nil
 
       at_exit { stop }
@@ -29,15 +37,15 @@ module NewRelicLogger
 
     def run
       loop do
-        message = @queue.pop
-        break if message == STOP_MESSAGE
+        messages = @queue.pop_with_timeout(QUEUE_WAIT_TIMEOUT)
+        logs     = LOGS_PAYLOAD.gsub(LOGS_PAYLOAD_REGEX, messages.join(',').prepend(OPEN_BRACKET).concat(CLOSE_BRACKET))
 
-        response = Net::HTTP.post(REGIONS[@region], { service: ENV['NEW_RELIC_APP_NAME'], message: message }.to_json, headers)
+        response = Net::HTTP.post(REGIONS[@region], logs, headers)
 
         begin
           response.value # raises an error if the post was unsuccessful
         rescue => e
-          NewRelic::Agent.notice_error(e, custom_params: { message: message })
+          NewRelic::Agent.notice_error(e)
         end
       end
     end
@@ -53,7 +61,7 @@ module NewRelicLogger
     end
 
     def stop
-      @queue << STOP_MESSAGE
+      @queue.close
 
       STOP_MAX_WAIT.div(STOP_WAIT_STEP).times do
         break if @queue.empty?
@@ -61,7 +69,6 @@ module NewRelicLogger
         sleep STOP_WAIT_STEP
       end
 
-      @queue.close
       @thread&.exit
     end
   end

--- a/lib/new_relic_logger/log_queue.rb
+++ b/lib/new_relic_logger/log_queue.rb
@@ -1,0 +1,52 @@
+module NewRelicLogger
+  class LogQueue
+
+    def initialize(max_queue_size)
+      if max_queue_size <= 0
+        raise IllegalArgumentException.new('max_queue_size must be greater than 0')
+      end
+
+      @queue_open     = true
+      @max_queue_size = max_queue_size
+      @queue          = []
+      @mutex          = Mutex.new
+      @cv             = ConditionVariable.new
+    end
+
+    def <<(message)
+      unless @queue_open
+        raise ClosedQueueError.new('queue closed')
+      end
+
+      @mutex.synchronize do
+        @queue << message
+        @cv.signal if @queue.length >= @max_queue_size
+      end
+    end
+
+    def pop_with_timeout(timeout)
+      if timeout <= 0
+        raise IllegalArgumentException.new('timeout must be greater than 0')
+      end
+
+      @mutex.synchronize do
+        while @queue.empty? || !@queue_open
+          @cv.wait(@mutex, timeout)
+        end
+
+        @queue.shift(@queue_open ? @max_queue_size : @queue.length)
+      end
+    end
+
+    def empty?
+      @mutex.synchronize do
+        @queue.empty?
+      end
+    end
+
+    def close
+      @queue_open = false
+      @cv.signal
+    end
+  end
+end

--- a/lib/new_relic_logger/version.rb
+++ b/lib/new_relic_logger/version.rb
@@ -1,3 +1,3 @@
 module NewRelicLogger
-  VERSION = "1.0.0"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
Updates the logic to operate on batches of logs instead of 1 at a time

https://app.clubhouse.io/forever/story/13372/bug-new-relic-logging-is-causing-high-memory-errors-in-heroku